### PR TITLE
Fix initialization of undo/redo

### DIFF
--- a/src/ide/modeleditor/case/casemodeleditor.ts
+++ b/src/ide/modeleditor/case/casemodeleditor.ts
@@ -62,6 +62,13 @@ export default class CaseModelEditor extends ModelEditor {
         super.visible = true;
     }
 
+    updateUndoRedoButtons(): void {
+        // Only update the buttons if the case is loaded. The call to resetActionBuffer in open() will not have the case loaded yet.
+        if (this.case) {
+            this.case.undoBox.refresh();
+        }
+    }
+
     /**
      * Imports the source and tries to visualize it
      */

--- a/src/ide/modeleditor/case/undoredo/undomanager.ts
+++ b/src/ide/modeleditor/case/undoredo/undomanager.ts
@@ -9,11 +9,6 @@ export default class UndoManager {
 
     constructor(public editor: CaseModelEditor) { }
 
-    updateUndoRedoButtons(undoCount: number = this.getUndoCount(), redoCount: number = this.getRedoCount()): void {
-        // Only update the buttons once the case is loaded.
-        if (this.editor.case) this.editor.case.undoBox.updateButtons(undoCount, redoCount);
-    }
-
     /**
      * Clears the action buffer, and prepares it for the new content.
      * This typically only happens when we open a new case model
@@ -54,16 +49,12 @@ export default class UndoManager {
         // Creating a new action makes it also the current action.
         //  Note that the actual action may not resolve in changes, and in such a case, the currentAction will return itself and remain the same.
         this.currentAction = new Action(this, caseDefinition, dimensions, this.currentAction as Action | undefined);
-        this.updateUndoRedoButtons();
+        this.editor.updateUndoRedoButtons();
         return this.currentAction as Action;
     }
 
     getUndoCount() {
-        if (this.currentAction) {
-            return this.currentAction.undoCount;
-        } else {
-            return 0;
-        }
+        return this.currentAction?.undoCount || 0;
     }
 
     async undo() {
@@ -74,15 +65,11 @@ export default class UndoManager {
         } else {
             console.log('No undo available');
         }
-        this.updateUndoRedoButtons();
+        this.editor.updateUndoRedoButtons();
     }
 
     getRedoCount() {
-        if (this.currentAction) {
-            return this.currentAction.redoCount;
-        } else {
-            return 0;
-        }
+        return this.currentAction?.redoCount || 0;
     }
 
     async redo() {
@@ -93,6 +80,6 @@ export default class UndoManager {
         } else {
             console.log('No redo availalbe');
         }
-        this.updateUndoRedoButtons();
+        this.editor.updateUndoRedoButtons();
     }
 }

--- a/src/ide/modeleditor/case/undoredo/undoredobox.ts
+++ b/src/ide/modeleditor/case/undoredo/undoredobox.ts
@@ -17,32 +17,24 @@ export default class UndoRedoBox {
             $(`<div class="formheader">
     <div>
         <div class="undo" type="button" title="Undo">
-            <span></span>
+            <span>${this.case.editor.undoManager.getUndoCount()}</span>
             <img src="${Images.Undo}" />
         </div>                
         <div class="redo" type="button" title="Redo">
             <img src="${Images.Redo}" />
-            <span></span>
+            <span>${this.case.editor.undoManager.getRedoCount()}</span>
         </div>
     </div>
 </div>`)
         );
-        html.find('.undo').on('click', () => this.undo());
-        html.find('.redo').on('click', () => this.redo());
+        html.find('.undo').on('click', () => this.case.editor.undoManager.undo());
+        html.find('.redo').on('click', () => this.case.editor.undoManager.redo());
         this.spanUndoCounter = html.find('.undo span');
         this.spanRedoCounter = html.find('.redo span');
     }
 
-    undo(): void {
-        this.case.editor.undoManager.undo();
-    }
-
-    redo(): void {
-        this.case.editor.undoManager.redo();
-    }
-
-    updateButtons(undoCount: number, redoCount: number): void {
-        this.spanUndoCounter.html(String(undoCount));
-        this.spanRedoCounter.html(String(redoCount));
+    refresh(): void {
+        this.spanUndoCounter.html(`${this.case.editor.undoManager.getUndoCount()}`);
+        this.spanRedoCounter.html(`${this.case.editor.undoManager.getRedoCount()}`);
     }
 }


### PR DESCRIPTION
Providing fix for: undo/redo did not start with (0, 0) visible in the box This is now always filled when the box is created. Undomanager now leaves updating the buttons to the CaseModelEditor. The case model editor tells the undobox to refresh. The undobox fetches fresh count from the manager when refreshing.