### PR TITLE
Support printing the case model

### DIFF
--- a/app/images/svg/print.svg
+++ b/app/images/svg/print.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" >
+    <path d="M0 0h48v48H0z" fill="none"/>
+    <g id="Shopicon">
+        <path d="M40,16h-4V4H12v12H8c-2.2,0-4,1.8-4,4v12c0,2.2,1.8,4,4,4h4v8h24v-8h4c2.2,0,4-1.8,4-4V20C44,17.8,42.2,16,40,16z M16,40
+		V28h16v12H16z M40,22c0,1.105-0.895,2-2,2c-1.105,0-2-0.895-2-2c0-1.105,0.895-2,2-2C39.105,20,40,20.895,40,22z M16,8h16v8H16V8z"
+		/>
+    </g>
+</svg>

--- a/src/ide/modeleditor/case/casemodeleditor.ts
+++ b/src/ide/modeleditor/case/casemodeleditor.ts
@@ -166,6 +166,13 @@ export default class CaseModelEditor extends ModelEditor {
                 break;
             case 90: //z
                 if (e.ctrlKey) this.undoManager.undo();
+            case 80: // P
+                if (e.ctrlKey) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.case.print();
+                }
+                break;
             default:
                 break;
         }

--- a/src/ide/modeleditor/case/elements/caseview.ts
+++ b/src/ide/modeleditor/case/elements/caseview.ts
@@ -314,6 +314,24 @@ export default class CaseView {
         return this.html.find('.divMarker');
     }
 
+    print() {
+        const svg = this.html[0].getElementsByTagName('svg')[0].outerHTML;
+        const printWindow = window.open('', '')!;
+        printWindow.document.open();
+        printWindow.document.write(`
+            <html>
+                <head>
+                    <title>${this.caseDefinition.name}</title>
+                </head>
+                <body>
+                    ${svg}
+                </body>
+            </html>`);
+        printWindow.document.close();
+        printWindow.print();
+        printWindow.close();
+    }
+
     /**
      * Renders the "source" view tab
      */

--- a/src/ide/modeleditor/case/elements/cmmnelementview.ts
+++ b/src/ide/modeleditor/case/elements/cmmnelementview.ts
@@ -130,6 +130,7 @@ export default abstract class CMMNElementView<D extends CMMNElementDefinition = 
                 fill: 'transparent',
                 stroke: '#423d3d',
                 strokeWidth: 1,
+                fontFamily: 'myriad-pro, Helvetica Neue, Helvetica, Arial, sans-serif',
             },
             body: {
                 fill: 'transparent',

--- a/src/ide/modeleditor/case/elements/halo/cmmn/caseplanhalo.ts
+++ b/src/ide/modeleditor/case/elements/halo/cmmn/caseplanhalo.ts
@@ -6,6 +6,7 @@ import CaseOutputParametersHaloItem from "./item/caseplan/caseoutputparametersha
 import CaseRolesHaloItem from "./item/caseplan/caseroleshaloitem";
 import DebuggerHaloItem from "./item/caseplan/debuggerhaloitem";
 import DeployHaloItem from "./item/caseplan/deployhaloitem";
+import PrintHaloItem from "./item/caseplan/printhaloitem";
 import SeparatorHaloItem from "./item/caseplan/separatorhaloitem";
 import StartCaseSchemaHaloItem from "./item/caseplan/startcaseschemahaloitem";
 import ViewSourceHaloItem from "./item/caseplan/viewsourcehaloitem";
@@ -23,7 +24,7 @@ export default class CasePlanHalo extends Halo<CasePlanDefinition, CasePlanView>
             SeparatorHaloItem,
             CaseInputParametersHaloItem, CaseOutputParametersHaloItem, StartCaseSchemaHaloItem, CaseRolesHaloItem,
             SeparatorHaloItem,
-            ViewSourceHaloItem, DeployHaloItem, DebuggerHaloItem
+            PrintHaloItem, ViewSourceHaloItem, DeployHaloItem, DebuggerHaloItem
         );
     }
 

--- a/src/ide/modeleditor/case/elements/halo/cmmn/item/caseplan/printhaloitem.ts
+++ b/src/ide/modeleditor/case/elements/halo/cmmn/item/caseplan/printhaloitem.ts
@@ -1,0 +1,9 @@
+import Images from "../../../../../../../util/images/images";
+import Halo from "../../../halo";
+import HaloClickItem from "../../../haloclickitem";
+
+export default class PrintHaloItem extends HaloClickItem {
+    constructor(halo: Halo) {
+        super(halo, Images.Print, 'Print', e => this.halo.element.case.print());
+    }
+}

--- a/src/ide/util/images/images.ts
+++ b/src/ide/util/images/images.ts
@@ -1,6 +1,6 @@
 import autoCompleteImageUrl from '../../../../app/images/autocompletedecorator_32.png';
 import closeImageUrl from '../../../../app/images/close_32.png';
-import DebugImageUrl from '../../../../app/images/debug.png';
+import debugImageUrl from '../../../../app/images/debug.png';
 import deleteImageUrl from '../../../../app/images/delete_32.png';
 import delete64ImageUrl from '../../../../app/images/delete_64.png';
 import deployImageUrl from '../../../../app/images/deploy_128.png';
@@ -42,7 +42,8 @@ import userEventImageUrl from '../../../../app/images/svg/userevent.svg';
 import taskinputImageUrl from '../../../../app/images/task_input_128.png';
 import taskoutputImageUrl from '../../../../app/images/task_output_128.png';
 import undoImageUrl from '../../../../app/images/undo_128.png';
-import ViewSourceImageUrl from '../../../../app/images/viewsource_128.png';
+import printImageUrl from '../../../../app/images/svg/print.svg';
+import viewSourceImageUrl from '../../../../app/images/viewsource_128.png';
 import warningImageUrl from '../../../../app/images/warningproblem_32.png';
 import zoomInImageUrl from '../../../../app/images/zoomin_64.png';
 
@@ -81,8 +82,9 @@ export default class Images {
     static Roles = rolesImageUrl;
     static StartCaseSchema = startCaseSchemaImageUrl;
     static Deploy = deployImageUrl;
-    static ViewSource = ViewSourceImageUrl;
-    static Debug = DebugImageUrl;
+    static Print = printImageUrl;
+    static ViewSource = viewSourceImageUrl;
+    static Debug = debugImageUrl;
 
     static TaskInput = taskinputImageUrl;
     static TaskOutput = taskoutputImageUrl;


### PR DESCRIPTION
Styling is now fully copied into the document, because otherwise the font is lost. A better alternative is to put the font into the svg elements explicitly